### PR TITLE
Fix memory smashing

### DIFF
--- a/src/subprj/STLQuickLook/STLPreviewGenerator.m
+++ b/src/subprj/STLQuickLook/STLPreviewGenerator.m
@@ -235,7 +235,8 @@ const CGFloat kRenderUpsizeFaktor=3.;
             
             
             glColor4f(1., 0., 0., .5);
-            GLfloat* rasterLines = calloc((size_t)(dimBuildPlattform.x/10.)*2, sizeof(GLfloat));
+            size_t rasterLinesSize = ceil((dimBuildPlattform.x - zeroBuildPlattform.x - -zeroBuildPlattform.x) / 10.0) * 6;
+            GLfloat* rasterLines = calloc(rasterLinesSize, sizeof(GLfloat));
             NSInteger i=0;
             for(CGFloat x = -zeroBuildPlattform.x; x<dimBuildPlattform.x-zeroBuildPlattform.x; x+=10.)
             {


### PR DESCRIPTION
Array for raster lines is allocated with wrong size.
